### PR TITLE
added updateOnScroll / initialIndex

### DIFF
--- a/lib/scroll_snap_list.dart
+++ b/lib/scroll_snap_list.dart
@@ -212,7 +212,7 @@ class ScrollSnapListState extends State<ScrollSnapList> {
                   _animateScroll(offset);
                 }
               } else if (scrollInfo is ScrollUpdateNotification &&
-                  widget.updateOnScroll) {
+                  widget.updateOnScroll == true) {
                 // dont notify the listener until after the first drag
                 if (widget.onItemFocus != null && isInit == false) {
                   int cardIndex =

--- a/lib/scroll_snap_list.dart
+++ b/lib/scroll_snap_list.dart
@@ -76,6 +76,7 @@ class ScrollSnapList extends StatefulWidget {
   ScrollSnapList({
     this.background,
     @required this.itemBuilder,
+    ScrollController listController,
     this.curve = Curves.ease,
     this.duration = 500,
     this.endOfListTolerance,
@@ -92,8 +93,7 @@ class ScrollSnapList extends StatefulWidget {
     this.updateOnScroll,
     this.initialIndex,
     this.scrollDirection = Axis.horizontal,
-    this.listController = ScrollController(),
-  }) : super(key: key);
+  }) : listController = listController ?? ScrollController(), super(key: key);
 
   @override
   ScrollSnapListState createState() => ScrollSnapListState();

--- a/lib/scroll_snap_list.dart
+++ b/lib/scroll_snap_list.dart
@@ -159,7 +159,7 @@ class ScrollSnapListState extends State<ScrollSnapList> {
   }
 
   void focusToInitialPosition() {
-    _animateScroll((widget.initialIndex * widget.itemSize).toDouble());
+    _listController.jumpTo((widget.initialIndex * widget.itemSize));
   }
 
   ///Trigger callback on reach end-of-list

--- a/lib/scroll_snap_list.dart
+++ b/lib/scroll_snap_list.dart
@@ -71,6 +71,8 @@ class ScrollSnapList extends StatefulWidget {
 
   final Axis scrollDirection;
 
+  final ScrollController listController;
+  
   ScrollSnapList({
     this.background,
     @required this.itemBuilder,
@@ -90,6 +92,7 @@ class ScrollSnapList extends StatefulWidget {
     this.updateOnScroll,
     this.initialIndex,
     this.scrollDirection = Axis.horizontal,
+    this.listController = ScrollController(),
   }) : super(key: key);
 
   @override
@@ -97,8 +100,6 @@ class ScrollSnapList extends StatefulWidget {
 }
 
 class ScrollSnapListState extends State<ScrollSnapList> {
-  ScrollController _listController = ScrollController();
-
   //true if initialIndex exists and first drag hasn't occurred
   bool isInit = true;
 
@@ -116,7 +117,7 @@ class ScrollSnapListState extends State<ScrollSnapList> {
   ///Scroll list to an offset
   void _animateScroll(double location) {
     Future.delayed(Duration.zero, () {
-      _listController.animateTo(
+      widget.listController.animateTo(
         location,
         duration: new Duration(milliseconds: widget.duration),
         curve: widget.curve,
@@ -159,7 +160,7 @@ class ScrollSnapListState extends State<ScrollSnapList> {
   }
 
   void focusToInitialPosition() {
-    _listController.jumpTo((widget.initialIndex * widget.itemSize));
+    widget.listController.jumpTo((widget.initialIndex * widget.itemSize));
   }
 
   ///Trigger callback on reach end-of-list
@@ -169,7 +170,7 @@ class ScrollSnapListState extends State<ScrollSnapList> {
 
   @override
   void dispose() {
-    _listController.dispose();
+    widget.listController.dispose();
     super.dispose();
   }
 
@@ -224,7 +225,7 @@ class ScrollSnapListState extends State<ScrollSnapList> {
               return true;
             },
             child: ListView.builder(
-              controller: _listController,
+              controller: widget.listController,
               padding: widget.scrollDirection == Axis.horizontal
                   ? EdgeInsets.symmetric(horizontal: _listPadding)
                   : EdgeInsets.symmetric(

--- a/lib/scroll_snap_list.dart
+++ b/lib/scroll_snap_list.dart
@@ -188,12 +188,6 @@ class ScrollSnapListState extends State<ScrollSnapList> {
           return NotificationListener<ScrollNotification>(
             onNotification: (ScrollNotification scrollInfo) {
               if (scrollInfo is ScrollEndNotification) {
-                // dont snap until after the initial position
-                if (isInit) {
-                  isInit = false;
-                  return true;
-                }
-
                 double tolerance =
                     widget.endOfListTolerance ?? (widget.itemSize / 2);
                 if (scrollInfo.metrics.pixels >=
@@ -213,7 +207,12 @@ class ScrollSnapListState extends State<ScrollSnapList> {
                 }
               } else if (scrollInfo is ScrollUpdateNotification &&
                   widget.updateOnScroll == true) {
-                // dont notify the listener until after the first drag
+                // dont snap until after the initial position
+                if (isInit) {
+                  isInit = false;
+                  return true;
+                }
+
                 if (widget.onItemFocus != null && isInit == false) {
                   int cardIndex =
                       ((scrollInfo.metrics.pixels - widget.itemSize / 2) /


### PR DESCRIPTION
I'm using this library for a duration selector with 30-minute increments. I wanted to be able to show a previously existing time which may not be at a 30-minute interval prior to selecting a new duration.
![timerlist1](https://user-images.githubusercontent.com/22828049/71493373-9d762500-2803-11ea-8847-d2eb6ed9889f.PNG)
![timerlist2](https://user-images.githubusercontent.com/22828049/71493378-a4049c80-2803-11ea-85dd-19b4b4e11bc9.PNG)
I have added an optional initialIndex which sets the list to a position potentially in-between snap points, until the first drag occurs. If the initialIndex = 3.5, this will set the list position to 3.5 * itemSize. 

I have also added an updateOnScroll boolean which allows for notifying the onItemFocus function on every ScrollUpdateNotification as opposed to only onScrollEnd.