### PR TITLE
Fix flutter 3 warning for WidgetsBinding

### DIFF
--- a/lib/scroll_snap_list.dart
+++ b/lib/scroll_snap_list.dart
@@ -174,7 +174,7 @@ class ScrollSnapListState extends State<ScrollSnapList> {
 
   void initState() {
     super.initState();
-    WidgetsBinding.instance!.addPostFrameCallback((_) {
+    WidgetsBinding.instance?.addPostFrameCallback((_) {
       if (widget.initialIndex != null) {
         //set list's initial position
         focusToInitialPosition();


### PR DESCRIPTION
When run before changes it gives the following error:
```
../../.pub-cache/hosted/pub.dartlang.org/scroll_snap_list-0.8.6/lib/scroll_snap_list.dart:177:20: Warning: Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null.
 - 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('../../Flutter/packages/flutter/lib/src/widgets/binding.dart').
    WidgetsBinding.instance!.addPostFrameCallback((_) {
                   ^
```